### PR TITLE
Issue/6 - Adds the batch response adapter, and tests

### DIFF
--- a/lib/Adapters/Batch_Response_Adapter.php
+++ b/lib/Adapters/Batch_Response_Adapter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Adiungo\Integrations\WordPress\Adapters;
+
+
+use Adiungo\Core\Abstracts\Batch_Response_Adapter as Core_Batch_Response_Adapter;
+use Underpin\Helpers\Array_Helper;
+
+class Batch_Response_Adapter extends Core_Batch_Response_Adapter
+{
+    /**
+     * @return mixed[][]
+     */
+    public function to_array(): array
+    {
+        $response = Array_Helper::wrap(json_decode($this->get_response(), true));
+
+        return Array_Helper::wrap($response['posts'] ?? []);
+    }
+}

--- a/tests/Unit/Adapters/Batch_Response_Adapter_Test.php
+++ b/tests/Unit/Adapters/Batch_Response_Adapter_Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Adiungo\Integrations\WordPress\Tests\Unit\Adapters;
+
+
+use Adiungo\Integrations\WordPress\Adapters\Batch_Response_Adapter;
+use Adiungo\Tests\Test_Case;
+use Generator;
+use Mockery;
+
+class Batch_Response_Adapter_Test extends Test_Case
+{
+
+    /**
+     * @covers       \Adiungo\Integrations\WordPress\Adapters\Batch_Response_Adapter::to_array()
+     * @dataProvider provider_convert_to_array
+     * @param mixed[] $expected
+     * @param string $response
+     * @return void
+     */
+    public function test_can_convert_to_array(array $expected, string $response): void
+    {
+        $instance = Mockery::mock(Batch_Response_Adapter::class)->makePartial();
+
+        $instance->allows('get_response')->andReturn($response);
+
+        $this->assertEquals($expected, $instance->to_array());
+    }
+
+    /** @see test_can_convert_to_array */
+    protected function provider_convert_to_array(): Generator
+    {
+        yield 'returns array when posts are set' => [['foo'], '{"posts": ["foo"]}'];
+        yield 'returns empty when posts are not set' => [[], '{"somethingElse": ["foo"]}'];
+        yield 'returns array when posts is not an array' => [['invalid'], '{"posts": "invalid"}'];
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #6 

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.