### PR TITLE
Issue/30 - Implement Post_Rest_Strategy_Factory::build_data_source

### DIFF
--- a/lib/Factories/Post_Rest_Strategy_Factory.php
+++ b/lib/Factories/Post_Rest_Strategy_Factory.php
@@ -21,105 +21,117 @@ use Underpin\Registries\Param_Collection;
 
 class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strategy
 {
-	use With_Http_Strategy;
-	use With_Index_Strategy;
+    use With_Http_Strategy;
+    use With_Index_Strategy;
 
-	/**
-	 * Assembles the items specific to this integration that are always the same.
-	 *
-	 * @return Rest
-	 */
-	protected function get_instance_template() : Rest
-	{
-		return new Rest();
-	}
+    /**
+     * Assembles the items specific to this integration that are always the same.
+     *
+     * @return Rest
+     */
+    protected function get_instance_template(): Rest
+    {
+        return new Rest();
+    }
 
-	/**
-	 * Builds the index strategy
-	 *
-	 * @param Url                   $base               The base URL to use to fetch content. Usually this is the REST
-	 *                                                  endpoint used to fetch bulk content.
-	 * @param DateTime              $last_requested     The date/time this content was last requested. Use GMT timezone.
-	 * @param Param_Collection|null $batch_query_params Any custom query params that need to be included on batch
-	 *                                                  requests.
-	 *
-	 * @return Index_Strategy
-	 * @throws Operation_Failed
-	 * @throws Validation_Failed
-	 */
-	public function build(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null) : Index_Strategy
-	{
-		return (new Index_Strategy())
-			->set_data_source($this->build_data_source($base, $last_requested, $batch_query_params));
-	}
+    /**
+     * Builds the index strategy
+     *
+     * @param Url $base The base URL to use to fetch content. Usually this is the REST
+     *                                                  endpoint used to fetch bulk content.
+     * @param DateTime $last_requested The date/time this content was last requested. Use GMT timezone.
+     * @param Param_Collection|null $batch_query_params Any custom query params that need to be included on batch
+     *                                                  requests.
+     *
+     * @return Index_Strategy
+     * @throws Operation_Failed
+     * @throws Validation_Failed
+     */
+    public function build(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null): Index_Strategy
+    {
+        return (new Index_Strategy())
+            ->set_data_source($this->build_data_source($base, $last_requested, $batch_query_params));
+    }
 
-	/**
-	 * Builds the has more strategy using the provided date.
-	 *
-	 * @param DateTime $last_requested The last requested date. Use GMT.
-	 *
-	 * @return Updated_Date_Strategy
-	 */
-	protected function build_has_more_strategy(DateTime $last_requested) : Updated_Date_Strategy
-	{
-		return (new Updated_Date_Strategy())->set_updated_date($last_requested);
-	}
+    /**
+     * Builds the has more strategy using the provided date.
+     *
+     * @param DateTime $last_requested The last requested date. Use GMT.
+     *
+     * @return Updated_Date_Strategy
+     */
+    protected function build_has_more_strategy(DateTime $last_requested): Updated_Date_Strategy
+    {
+        return (new Updated_Date_Strategy())->set_updated_date($last_requested);
+    }
 
-	/**
-	 * Builds the batch request.
-	 *
-	 * @param Url                   $base
-	 * @param Param_Collection|null $batch_query_params
-	 *
-	 * @return Request
-	 * @throws Operation_Failed
-	 * @throws Validation_Failed
-	 */
-	protected function build_batch_request(Url $base, ?Param_Collection $batch_query_params = null) : Request
-	{
-		$base->get_params()->merge($batch_query_params);
+    /**
+     * Attempts to set a param on the URL, but does not set if it already exists.
+     *
+     * @param Url $base
+     * @param Param $param
+     * @return Url
+     * @throws Operation_Failed
+     */
+    protected function maybe_set_param(Url $base, Param $param): Url
+    {
+        try {
+            $base->get_params()->get($param->get_id());
+        } catch (Unknown_Registry_Item $e) {
+            $base->add_param($param);
+        }
 
-		// Set the order and order by params.
-		try {
-			$base->get_params()->get('orderby');
-		} catch (Unknown_Registry_Item $e) {
-			$base->add_param((new Param('orderby', Types::String))->set_value('modified'));
-		}
+        return $base;
+    }
 
-		try {
-			$base->get_params()->get('order');
-		} catch (Unknown_Registry_Item $e) {
-			$base->add_param((new Param('order', Types::String))->set_value('desc'));
-		}
+    /**
+     * Builds the batch request.
+     *
+     * @param Url $base
+     * @param Param_Collection|null $batch_query_params
+     *
+     * @return Request
+     * @throws Operation_Failed
+     * @throws Validation_Failed
+     */
+    protected function build_batch_request(Url $base, ?Param_Collection $batch_query_params = null): Request
+    {
+        if ($batch_query_params instanceof Param_Collection) {
+            $batch_query_params->each(fn(Param $param) => $this->maybe_set_param($base, $param));
+        }
 
-		return (new Request())->set_url($base);
-	}
+        // Set the order and order by params.
+        $this->maybe_set_param($base, (new Param('orderby', Types::String))->set_value('modified'));
+        $this->maybe_set_param($base, (new Param('order', Types::String))->set_value('desc'));
 
-	/**
-	 * Builds the single request.
-	 *
-	 * @param Url $base
-	 *
-	 * @return Request
-	 */
-	protected function build_single_request(Url $base) : Request
-	{
-		return (new Request())->set_url($base);
-	}
+        return (new Request())->set_url($base);
+    }
 
-	/**
-	 * Builds the instance.
-	 * Note that this does NOT implement set the HTTP strategy. That is up to the platform to set.
-	 *
-	 * @throws Operation_Failed|Validation_Failed
-	 */
-	protected function build_data_source(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null) : Rest
-	{
-		$result = $this->get_instance_template();
-		$result->get_single_request_builder()->set_request($this->build_single_request($base));
-		$result->get_batch_request_builder()->set_request($this->build_batch_request($base, $batch_query_params));
-		$result->set_has_more_strategy($this->build_has_more_strategy($last_requested));
+    /**
+     * Builds the single request.
+     *
+     * @param Url $base
+     *
+     * @return Request
+     */
+    protected function build_single_request(Url $base): Request
+    {
+        return (new Request())->set_url($base);
+    }
 
-		return $result;
-	}
+    /**
+     * Builds the instance.
+     * Note that this does NOT implement set the HTTP strategy. That is up to the platform to set.
+     *
+     * @throws Operation_Failed|Validation_Failed
+     */
+    protected function build_data_source(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null): Rest
+    {
+        $result = $this->get_instance_template();
+        $result->get_single_request_builder()->set_request($this->build_single_request($base));
+        $result->get_batch_request_builder()->set_request($this->build_batch_request($base, $batch_query_params));
+        $result->set_has_more_strategy($this->build_has_more_strategy($last_requested));
+
+        return $result;
+    }
 }

--- a/lib/Factories/Post_Rest_Strategy_Factory.php
+++ b/lib/Factories/Post_Rest_Strategy_Factory.php
@@ -4,49 +4,122 @@ namespace Adiungo\Integrations\WordPress\Factories;
 
 use Adiungo\Core\Factories\Data_Sources\Rest;
 use Adiungo\Core\Factories\Index_Strategy;
+use Adiungo\Core\Factories\Updated_Date_Strategy;
 use Adiungo\Core\Interfaces\Has_Http_Strategy;
 use Adiungo\Core\Interfaces\Has_Index_Strategy;
 use Adiungo\Core\Traits\With_Http_Strategy;
 use Adiungo\Core\Traits\With_Index_Strategy;
 use DateTime;
+use Underpin\Enums\Types;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+use Underpin\Exceptions\Validation_Failed;
+use Underpin\Factories\Registry_Items\Param;
+use Underpin\Factories\Request;
 use Underpin\Factories\Url;
 use Underpin\Registries\Param_Collection;
 
 class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strategy
 {
-    use With_Http_Strategy;
-    use With_Index_Strategy;
+	use With_Http_Strategy;
+	use With_Index_Strategy;
 
-    /**
-     * Assembles the items specific to this integration that are always the same.
-     *
-     * @return Rest
-     */
-    protected function get_instance_template(): Rest
-    {
-        return new Rest();
-    }
+	/**
+	 * Assembles the items specific to this integration that are always the same.
+	 *
+	 * @return Rest
+	 */
+	protected function get_instance_template() : Rest
+	{
+		return new Rest();
+	}
 
-    /**
-     * Builds the index strategy
-     *
-     * @param Url $base The base URL to use to fetch content. Usually this is the REST endpoint used to fetch bulk content.
-     * @param DateTime $last_requested The date/time this content was last requested. Use GMT timezone.
-     * @param Param_Collection|null $batch_query_params Any custom query params that need to be included on batch requests.
-     * @return Index_Strategy
-     */
-    public function build(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null): Index_Strategy
-    {
-        return (new Index_Strategy())
-            ->set_data_source($this->build_data_source($base, $last_requested, $batch_query_params));
-    }
+	/**
+	 * Builds the index strategy
+	 *
+	 * @param Url                   $base               The base URL to use to fetch content. Usually this is the REST
+	 *                                                  endpoint used to fetch bulk content.
+	 * @param DateTime              $last_requested     The date/time this content was last requested. Use GMT timezone.
+	 * @param Param_Collection|null $batch_query_params Any custom query params that need to be included on batch
+	 *                                                  requests.
+	 *
+	 * @return Index_Strategy
+	 * @throws Operation_Failed
+	 * @throws Validation_Failed
+	 */
+	public function build(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null) : Index_Strategy
+	{
+		return (new Index_Strategy())
+			->set_data_source($this->build_data_source($base, $last_requested, $batch_query_params));
+	}
 
-    /**
-     * Builds the instance.
-     * Note that this does NOT implement set the HTTP strategy. That is up to the platform to set.
-     */
-    protected function build_data_source(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params): Rest
-    {
-        return new Rest();
-    }
+	/**
+	 * Builds the has more strategy using the provided date.
+	 *
+	 * @param DateTime $last_requested The last requested date. Use GMT.
+	 *
+	 * @return Updated_Date_Strategy
+	 */
+	protected function build_has_more_strategy(DateTime $last_requested) : Updated_Date_Strategy
+	{
+		return (new Updated_Date_Strategy())->set_updated_date($last_requested);
+	}
+
+	/**
+	 * Builds the batch request.
+	 *
+	 * @param Url                   $base
+	 * @param Param_Collection|null $batch_query_params
+	 *
+	 * @return Request
+	 * @throws Operation_Failed
+	 * @throws Validation_Failed
+	 */
+	protected function build_batch_request(Url $base, ?Param_Collection $batch_query_params = null) : Request
+	{
+		$base->get_params()->merge($batch_query_params);
+
+		// Set the order and order by params.
+		try {
+			$base->get_params()->get('orderby');
+		} catch (Unknown_Registry_Item $e) {
+			$base->add_param((new Param('orderby', Types::String))->set_value('modified'));
+		}
+
+		try {
+			$base->get_params()->get('order');
+		} catch (Unknown_Registry_Item $e) {
+			$base->add_param((new Param('order', Types::String))->set_value('desc'));
+		}
+
+		return (new Request())->set_url($base);
+	}
+
+	/**
+	 * Builds the single request.
+	 *
+	 * @param Url $base
+	 *
+	 * @return Request
+	 */
+	protected function build_single_request(Url $base) : Request
+	{
+		return (new Request())->set_url($base);
+	}
+
+	/**
+	 * Builds the instance.
+	 * Note that this does NOT implement set the HTTP strategy. That is up to the platform to set.
+	 *
+	 * @throws Operation_Failed|Validation_Failed
+	 */
+	protected function build_data_source(Url $base, DateTime $last_requested, ?Param_Collection $batch_query_params = null) : Rest
+	{
+		$result = $this->get_instance_template();
+		$result->get_single_request_builder()->set_request($this->build_single_request($base));
+		$result->get_batch_request_builder()->set_request($this->build_batch_request($base, $batch_query_params));
+		$result->set_has_more_strategy($this->build_has_more_strategy($last_requested));
+
+		return $result;
+	}
 }

--- a/lib/Factories/Post_Rest_Strategy_Factory.php
+++ b/lib/Factories/Post_Rest_Strategy_Factory.php
@@ -97,7 +97,7 @@ class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strateg
     protected function build_batch_request(Url $base, ?Param_Collection $batch_query_params = null): Request
     {
         if ($batch_query_params instanceof Param_Collection) {
-            $batch_query_params->each(fn(Param $param) => $this->maybe_set_param($base, $param));
+            $batch_query_params->each(fn (Param $param) => $this->maybe_set_param($base, $param));
         }
 
         // Set the order and order by params.

--- a/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
+++ b/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
@@ -102,6 +102,7 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
 
         $date = new DateTime();
 
+        /** @var Updated_Date_Strategy $result */
         $result = $this->call_inaccessible_method($instance, 'build_has_more_strategy', $date);
 
         $this->assertSame($date, $result->get_updated_date());
@@ -120,6 +121,7 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
 
         $base = Url::from('foo.com');
 
+        /** @var Request $result **/
         $result = $this->call_inaccessible_method($instance, 'build_single_request', $base);
 
         $this->assertSame($result->get_url(), $base);
@@ -185,6 +187,7 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
             ->shouldAllowMockingProtectedMethods()
             ->makePartial();
 
+        /** @var Request $result **/
         $result = $this->call_inaccessible_method($instance, 'build_batch_request', $base, $batch_query_params);
 
         $url = $result->get_url();

--- a/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
+++ b/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
@@ -3,14 +3,20 @@
 namespace Adiungo\Integrations\WordPress\Tests\Unit\Factories;
 
 use Adiungo\Core\Factories\Data_Sources\Rest;
+use Adiungo\Core\Factories\Updated_Date_Strategy;
 use Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory;
 use Adiungo\Tests\Test_Case;
+use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use DateTime;
 use Mockery;
+use Underpin\Factories\Request;
 use Underpin\Factories\Url;
+use Underpin\Registries\Param_Collection;
 
 class Post_Rest_Strategy_Factory_Test extends Test_Case
 {
+    use With_Inaccessible_Methods;
+
     /**
      * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::get_instance_template
      * @return void
@@ -45,6 +51,31 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
      */
     public function test_can_build_data_source(): void
     {
-        $this->markTestIncomplete();
+        $instance = Mockery::mock(Post_Rest_Strategy_Factory::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $base = Url::from('baz.com');
+        $batch_query_params = new Param_Collection();
+        $last_requested = new DateTime('10 minutes ago');
+
+        $expected = Mockery::mock(Rest::class);
+
+        $single_request = (new Request())->set_url(Url::from('foo.com'));
+        $batch_request = (new Request())->set_url(Url::from('bar.com'));
+        $has_more_strategy = new Updated_Date_Strategy();
+
+        $expected->expects('get_single_request_builder->set_request')->with($single_request);
+        $expected->expects('get_batch_request_builder->set_request')->with($batch_request);
+        $expected->expects('set_has_more_strategy')->with($has_more_strategy);
+
+        $instance->allows('build_single_request')->andReturn($single_request);
+        $instance->allows('build_batch_request')->with($base, $batch_query_params)->andReturn($batch_request);
+        $instance->allows('build_has_more_strategy')->with($last_requested)->andReturn($has_more_strategy);
+        $instance->allows('get_instance_template')->andReturn($expected);
+
+        $result = $this->call_inaccessible_method($instance, 'build_data_source', $base, $last_requested, $batch_query_params);
+
+        $this->assertSame($expected, $result);
     }
 }

--- a/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
+++ b/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
@@ -92,6 +92,22 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
     }
 
     /**
+     * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build_has_more_strategy
+     * @return void
+     * @throws ReflectionException|Url_Exception
+     */
+    public function test_can_build_has_more_strategy(): void
+    {
+        $instance = Mockery::mock(Post_Rest_Strategy_Factory::class)->makePartial();
+
+        $date = new DateTime();
+
+        $result = $this->call_inaccessible_method($instance, 'build_has_more_strategy', $date);
+
+        $this->assertSame($date, $result->get_updated_date());
+    }
+
+    /**
      * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build_single_request
      * @return void
      * @throws ReflectionException|Url_Exception

--- a/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
+++ b/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
@@ -8,7 +8,15 @@ use Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use DateTime;
+use Generator;
 use Mockery;
+use ReflectionException;
+use Underpin\Enums\Types;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+use Underpin\Exceptions\Url_Exception;
+use Underpin\Exceptions\Validation_Failed;
+use Underpin\Factories\Registry_Items\Param;
 use Underpin\Factories\Request;
 use Underpin\Factories\Url;
 use Underpin\Registries\Param_Collection;
@@ -29,6 +37,8 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
     /**
      * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build
      * @return void
+     * @throws Operation_Failed
+     * @throws Validation_Failed
      */
     public function test_can_build(): void
     {
@@ -48,6 +58,8 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
     /**
      * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build_data_source
      * @return void
+     * @throws Url_Exception
+     * @throws ReflectionException
      */
     public function test_can_build_data_source(): void
     {
@@ -77,5 +89,116 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
         $result = $this->call_inaccessible_method($instance, 'build_data_source', $base, $last_requested, $batch_query_params);
 
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build_single_request
+     * @return void
+     * @throws ReflectionException|Url_Exception
+     */
+    public function test_can_build_single_request(): void
+    {
+        $instance = Mockery::mock(Post_Rest_Strategy_Factory::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $base = Url::from('foo.com');
+
+        $result = $this->call_inaccessible_method($instance, 'build_single_request', $base);
+
+        $this->assertSame($result->get_url(), $base);
+    }
+
+    /**
+     * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::maybe_set_param()
+     *
+     * @return void
+     * @throws ReflectionException
+     * @throws Validation_Failed
+     */
+    public function test_maybe_set_param_adds_param_when_it_does_not_exist(): void
+    {
+        $instance = Mockery::mock(Post_Rest_Strategy_Factory::class)->makePartial();
+
+        $base = Mockery::mock(Url::class);
+        $param = (new Param('foo', Types::Integer))->set_value(1);
+
+        $base->allows('get_params->get')->with('foo')->andThrow(Unknown_Registry_Item::class);
+        $base->expects('add_param')->with($param)->once();
+
+        $result = $this->call_inaccessible_method($instance, 'maybe_set_param', $base, $param);
+
+        $this->assertSame($base, $result);
+    }
+
+    /**
+     * @covers \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::maybe_set_param()
+     *
+     * @return void
+     * @throws ReflectionException
+     * @throws Validation_Failed
+     */
+    public function test_maybe_set_param_does_not_add_param_when_it_exists(): void
+    {
+        $instance = Mockery::mock(Post_Rest_Strategy_Factory::class)->makePartial();
+
+        $base = Mockery::mock(Url::class);
+        $param = (new Param('foo', Types::Integer))->set_value(1);
+
+        $base->allows('get_params->get')->with('foo')->andReturn($param);
+        $base->expects('add_param')->never();
+
+        $result = $this->call_inaccessible_method($instance, 'maybe_set_param', $base, $param);
+
+        $this->assertSame($base, $result);
+    }
+
+
+    /**
+     * @covers       \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build_batch_request
+     * @param Url $expected
+     * @param Url $base
+     * @param Param_Collection|null $batch_query_params
+     * @return void
+     * @throws ReflectionException
+     * @dataProvider provider_can_build_batch_request
+     */
+    public function test_can_build_batch_request(Url $expected, Url $base, ?Param_Collection $batch_query_params): void
+    {
+        $instance = Mockery::mock(Post_Rest_Strategy_Factory::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $result = $this->call_inaccessible_method($instance, 'build_batch_request', $base, $batch_query_params);
+
+        $url = $result->get_url();
+
+        $this->assertSame($result->get_url(), $base);
+        $this->assertEquals($expected, $url);
+    }
+
+    /**
+     * @return Generator
+     * @throws Operation_Failed
+     * @throws Validation_Failed
+     * @see test_can_build_batch_request
+     */
+    public function provider_can_build_batch_request(): Generator
+    {
+        yield 'It sets batch URL params' => [
+            (new Url())
+                ->add_param((new Param('foo', Types::String))->set_value('bar'))
+                ->add_param((new Param('orderby', Types::String))->set_value('modified'))
+                ->add_param((new Param('order', Types::String))->set_value('desc')),
+            new Url(),
+            (new Param_Collection())->add('foo', (new Param('foo', Types::String))->set_value('bar'))
+        ];
+        yield 'It sets orderby and order by default' => [
+            (new Url())
+                ->add_param((new Param('orderby', Types::String))->set_value('modified'))
+                ->add_param((new Param('order', Types::String))->set_value('desc')),
+            new Url(),
+            null
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Resolves #30 

This PR implements the `Post_Rest_Strategy_Factory::build_data_source` method, as well as any related method that was necessary to fulfill this in a testable fashion.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.