### PR TITLE
Issue/34 - Implement build_data_source_adapter and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ vendor
 
 ### Caches ###
 *.cache
+/.idea/

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "adiungo/core",
-            "version": "0.1.3",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/adiungo/core.git",
-                "reference": "b90db6ab14c6e71c13268ba3a2f885aec40a15b6"
+                "reference": "72242ee89274927a00feca2000105fa4f5cb19c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adiungo/core/zipball/b90db6ab14c6e71c13268ba3a2f885aec40a15b6",
-                "reference": "b90db6ab14c6e71c13268ba3a2f885aec40a15b6",
+                "url": "https://api.github.com/repos/adiungo/core/zipball/72242ee89274927a00feca2000105fa4f5cb19c1",
+                "reference": "72242ee89274927a00feca2000105fa4f5cb19c1",
                 "shasum": ""
             },
             "require": {
@@ -59,7 +59,7 @@
                 "source": "https://github.com/adiungo/core/releases",
                 "wiki": "https://github.com/adiungo/core/wiki"
             },
-            "time": "2022-12-18T16:00:59+00:00"
+            "time": "2023-01-02T11:53:48+00:00"
         },
         {
             "name": "composer/installers",
@@ -4397,5 +4397,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "adiungo/core",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/adiungo/core.git",
-                "reference": "72242ee89274927a00feca2000105fa4f5cb19c1"
+                "reference": "30d45c9361d1be6f7d49c75975a6f39c3e6bcc96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adiungo/core/zipball/72242ee89274927a00feca2000105fa4f5cb19c1",
-                "reference": "72242ee89274927a00feca2000105fa4f5cb19c1",
+                "url": "https://api.github.com/repos/adiungo/core/zipball/30d45c9361d1be6f7d49c75975a6f39c3e6bcc96",
+                "reference": "30d45c9361d1be6f7d49c75975a6f39c3e6bcc96",
                 "shasum": ""
             },
             "require": {
@@ -59,7 +59,7 @@
                 "source": "https://github.com/adiungo/core/releases",
                 "wiki": "https://github.com/adiungo/core/wiki"
             },
-            "time": "2023-01-02T11:53:48+00:00"
+            "time": "2023-01-02T15:45:34+00:00"
         },
         {
             "name": "composer/installers",

--- a/lib/Factories/Post_Rest_Strategy_Factory.php
+++ b/lib/Factories/Post_Rest_Strategy_Factory.php
@@ -76,8 +76,8 @@ class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strateg
             ->map_field('excerpt.rendered', 'set_excerpt', Types::String)
             ->map_field('title.rendered', 'set_name', Types::String)
             ->map_field('modified_gmt', 'set_updated_date', fn (string $value) => $this->adapt_date($value))
-            ->map_field('categories', 'add_categories', fn (array $categories) => Array_Helper::map($categories, fn (int $id) => (new Category())->set_id($id)))
-            ->map_field('tags', 'add_tags', fn (array $tags) => Array_Helper::map($tags, fn (int $id) => (new Tag())->set_id($id)))
+            ->map_field('categories', 'add_categories', fn (array $categories) => Array_Helper::map($categories, fn (int $id) => (new WordPress_Category())->set_remote_id($id)))
+            ->map_field('tags', 'add_tags', fn (array $tags) => Array_Helper::map($tags, fn (int $id) => (new WordPress_Tag())->set_remote_id($id)))
             ->map_field('date_gmt', 'set_published_date', fn (string $value) => $this->adapt_date($value));
     }
 

--- a/lib/Factories/Post_Rest_Strategy_Factory.php
+++ b/lib/Factories/Post_Rest_Strategy_Factory.php
@@ -71,14 +71,14 @@ class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strateg
         return (new Data_Source_Adapter())
             ->set_content_model_instance(Post::class)
             ->map_field('id', 'set_id', Types::Integer)
-            ->map_field('link', 'set_origin', fn(string $origin) => Url::from($origin))
+            ->map_field('link', 'set_origin', fn (string $origin) => Url::from($origin))
             ->map_field('content.rendered', 'set_content', Types::String)
             ->map_field('excerpt.rendered', 'set_excerpt', Types::String)
             ->map_field('title.rendered', 'set_name', Types::String)
-            ->map_field('modified_gmt', 'set_updated_date', fn(string $value) => $this->adapt_date($value))
-            ->map_field('categories', 'add_categories', fn(array $categories) => Array_Helper::map($categories, fn(int $id) => (new Category())->set_id($id)))
-            ->map_field('tags', 'add_tags', fn(array $tags) => Array_Helper::map($tags, fn(int $id) => (new Tag())->set_id($id)))
-            ->map_field('date_gmt', 'set_published_date', fn(string $value) => $this->adapt_date($value));
+            ->map_field('modified_gmt', 'set_updated_date', fn (string $value) => $this->adapt_date($value))
+            ->map_field('categories', 'add_categories', fn (array $categories) => Array_Helper::map($categories, fn (int $id) => (new Category())->set_id($id)))
+            ->map_field('tags', 'add_tags', fn (array $tags) => Array_Helper::map($tags, fn (int $id) => (new Tag())->set_id($id)))
+            ->map_field('date_gmt', 'set_published_date', fn (string $value) => $this->adapt_date($value));
     }
 
     /**
@@ -86,6 +86,7 @@ class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strateg
      *
      * @param string $value
      * @return DateTime
+     * @throws Operation_Failed
      */
     protected function adapt_date(string $value): DateTime
     {
@@ -93,7 +94,10 @@ class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strateg
         if (!str_contains($value, '+')) {
             $value = String_Helper::append($value, '+00:00');
         }
-        return DateTime::createFromFormat(DATE_ATOM, $value);
+
+        $result = DateTime::createFromFormat(DATE_ATOM, $value);
+
+        return $result ?: throw new Operation_Failed('Could not create date');
     }
 
     /**
@@ -159,7 +163,7 @@ class Post_Rest_Strategy_Factory implements Has_Http_Strategy, Has_Index_Strateg
     protected function build_batch_request(Url $base, ?Param_Collection $batch_query_params = null): Request
     {
         if ($batch_query_params instanceof Param_Collection) {
-            $batch_query_params->each(fn(Param $param) => $this->maybe_set_param($base, $param));
+            $batch_query_params->each(fn (Param $param) => $this->maybe_set_param($base, $param));
         }
 
         // Set the order and order by params.

--- a/lib/Factories/WordPress_Category.php
+++ b/lib/Factories/WordPress_Category.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Adiungo\Integrations\WordPress\Factories;
+
+use Adiungo\Core\Factories\Category;
+use Adiungo\Core\Interfaces\Has_Remote_Id;
+use Adiungo\Core\Traits\With_Remote_Id;
+use Adiungo\Integrations\WordPress\Traits\With_Fallback_Id;
+
+class WordPress_Category extends Category implements Has_Remote_Id
+{
+    use With_Remote_Id;
+    use With_Fallback_Id;
+}

--- a/lib/Factories/WordPress_Tag.php
+++ b/lib/Factories/WordPress_Tag.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Adiungo\Integrations\WordPress\Factories;
+
+use Adiungo\Core\Factories\Tag;
+use Adiungo\Core\Interfaces\Has_Remote_Id;
+use Adiungo\Core\Traits\With_Remote_Id;
+use Adiungo\Integrations\WordPress\Traits\With_Fallback_Id;
+
+class WordPress_Tag extends Tag implements Has_Remote_Id
+{
+    use With_Remote_Id;
+    use With_Fallback_Id;
+}

--- a/lib/Traits/With_Fallback_Id.php
+++ b/lib/Traits/With_Fallback_Id.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Adiungo\Integrations\WordPress\Traits;
+
+trait With_Fallback_Id
+{
+    protected string $id;
+    protected int $remote_id;
+
+    /**
+     * Updates get_id to fall back to remote ID when default ID is not set.
+     *
+     * This is necessary in some cases because the ID is expected when adding the item to the registry.
+     * Some remote calls only provide the ID of a category/tag, but we need to construct a category to store in a transient
+     * and fetch later. This allows that to happen.
+     *
+     * @return string
+     */
+    public function get_id(): string
+    {
+        if (isset($this->remote_id) && !isset($this->id)) {
+            return (string)$this->remote_id;
+        }
+
+        return $this->id;
+    }
+}

--- a/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
+++ b/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
@@ -10,6 +10,8 @@ use Adiungo\Core\Factories\Updated_Date_Strategy;
 use Adiungo\Integrations\WordPress\Adapters\Batch_Response_Adapter;
 use Adiungo\Integrations\WordPress\Adapters\Single_Response_Adapter;
 use Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory;
+use Adiungo\Integrations\WordPress\Factories\WordPress_Category;
+use Adiungo\Integrations\WordPress\Factories\WordPress_Tag;
 use Adiungo\Integrations\WordPress\Models\Post;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
@@ -295,19 +297,21 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
     public function provider_can_build_data_source_adapter(): Generator
     {
         $published = DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:03:52+00:00');
-        if(!$published){
+        if (!$published) {
             throw new Exception('invalid date');
         }
+
         $updated = DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:04:56+00:00');
-        if(!$updated){
+        if (!$updated) {
             throw new Exception('invalid date');
         }
+
         yield 'basic adaptation' => [
             (new Post())
                 ->set_id(1)
                 ->set_origin(Url::from('https://www.foo.bar'))
-                ->add_categories((new Category())->set_id(4), (new Category())->set_id(5), (new Category())->set_id(6))
-                ->add_tags((new Tag())->set_id(1), (new Tag())->set_id(2), (new Tag())->set_id(3))
+                ->add_tags((new WordPress_Tag())->set_remote_id(1), (new WordPress_Tag())->set_remote_id(2), (new WordPress_Tag())->set_remote_id(3))
+                ->add_categories((new WordPress_Category())->set_remote_id(4), (new WordPress_Category())->set_remote_id(5), (new WordPress_Category())->set_remote_id(6))
                 ->set_published_date($published)
                 ->set_updated_date($updated)
                 ->set_name('title baz')

--- a/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
+++ b/tests/Unit/Factories/Post_Rest_Strategy_Factory_Test.php
@@ -14,6 +14,7 @@ use Adiungo\Integrations\WordPress\Models\Post;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use DateTime;
+use Exception;
 use Generator;
 use Mockery;
 use ReflectionException;
@@ -55,11 +56,11 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
             ->andReturn($rest);
 
         $rest->expects('set_single_response_adapter')
-            ->withArgs(fn($arg) => $arg instanceof Single_Response_Adapter)
+            ->withArgs(fn ($arg) => $arg instanceof Single_Response_Adapter)
             ->andReturn($rest);
 
         $rest->expects('set_batch_response_adapter')
-            ->withArgs(fn($arg) => $arg instanceof Batch_Response_Adapter)
+            ->withArgs(fn ($arg) => $arg instanceof Batch_Response_Adapter)
             ->andReturn($rest);
 
 
@@ -273,7 +274,7 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
     /**
      * @covers       \Adiungo\Integrations\WordPress\Factories\Post_Rest_Strategy_Factory::build_data_source_adapter
      * @param Post $expected
-     * @param array $input
+     * @param mixed[] $input
      * @return void
      * @throws Operation_Failed
      * @throws ReflectionException
@@ -286,16 +287,29 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
         $this->assertEquals($expected, $adapter->convert_to_model($input));
     }
 
+    /**
+     * @return Generator
+     * @throws Operation_Failed
+     * @throws Url_Exception
+     */
     public function provider_can_build_data_source_adapter(): Generator
     {
+        $published = DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:03:52+00:00');
+        if(!$published){
+            throw new Exception('invalid date');
+        }
+        $updated = DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:04:56+00:00');
+        if(!$updated){
+            throw new Exception('invalid date');
+        }
         yield 'basic adaptation' => [
             (new Post())
                 ->set_id(1)
                 ->set_origin(Url::from('https://www.foo.bar'))
                 ->add_categories((new Category())->set_id(4), (new Category())->set_id(5), (new Category())->set_id(6))
                 ->add_tags((new Tag())->set_id(1), (new Tag())->set_id(2), (new Tag())->set_id(3))
-                ->set_published_date(DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:03:52+00:00'))
-                ->set_updated_date(DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:04:56+00:00'))
+                ->set_published_date($published)
+                ->set_updated_date($updated)
                 ->set_name('title baz')
                 ->set_content('content foo')
                 ->set_excerpt('excerpt bar'),
@@ -321,8 +335,8 @@ class Post_Rest_Strategy_Factory_Test extends Test_Case
             (new Post())
                 ->set_id(1)
                 ->set_origin(Url::from('https://www.foo.bar'))
-                ->set_published_date(DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:03:52+00:00'))
-                ->set_updated_date(DateTime::createFromFormat(DATE_ATOM, '2023-01-01T22:04:56+00:00'))
+                ->set_published_date($published)
+                ->set_updated_date($updated)
                 ->set_name('title baz')
                 ->set_content('content foo')
                 ->set_excerpt('excerpt bar'),

--- a/tests/Unit/Traits/With_Fallback_Id_Test.php
+++ b/tests/Unit/Traits/With_Fallback_Id_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Adiungo\Integrations\WordPress\Tests\Unit\Traits;
+
+use Adiungo\Integrations\WordPress\Traits\With_Fallback_Id;
+use Adiungo\Tests\Test_Case;
+use Adiungo\Tests\Traits\With_Inaccessible_Properties;
+use Generator;
+use Mockery;
+
+class With_Fallback_Id_Test extends Test_Case
+{
+    use With_Inaccessible_Properties;
+
+    /**
+     * @covers       \Adiungo\Integrations\WordPress\Traits\With_Fallback_Id::get_id
+     *
+     * @param string $expected
+     * @param string|null $id
+     * @param int|null $fallback_id
+     * @return void
+     * @throws \ReflectionException
+     * @dataProvider provider_can_get_id
+     */
+    public function test_can_get_id(string $expected, ?string $id, ?int $fallback_id): void
+    {
+        $instance = Mockery::mock(With_Fallback_Id::class);
+
+        if ($id) {
+            $this->set_protected_property($instance, 'id', $id);
+        }
+
+        if ($fallback_id) {
+            $this->set_protected_property($instance, 'remote_id', $fallback_id);
+        }
+
+        $this->assertSame($expected, $instance->get_id());
+    }
+
+    public function provider_can_get_id(): Generator
+    {
+        yield 'No id gets fallback' => ['123', null, 123];
+        yield 'With id gets id' => ['foo', 'foo', 345];
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #34 

This PR implements `build_data_source_adapter`. It also introduces a new method to handle processing the date. WordPress can filter pretty much anything so you can't assume the gmt date is going to be what you expect.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.